### PR TITLE
fix: First navigation press now goes to item 1 instead of item 2

### DIFF
--- a/AccessibilityMod/Services/HotspotNavigator.cs
+++ b/AccessibilityMod/Services/HotspotNavigator.cs
@@ -10,7 +10,7 @@ namespace AccessibilityMod.Services
     public static class HotspotNavigator
     {
         private static List<HotspotInfo> _hotspots = new List<HotspotInfo>();
-        private static int _currentIndex = 0;
+        private static int _currentIndex = -1;
 
         public class HotspotInfo
         {
@@ -98,7 +98,7 @@ namespace AccessibilityMod.Services
                 }
 
                 // Restore position to previously selected hotspot if it still exists
-                _currentIndex = 0;
+                _currentIndex = -1;
                 if (previousMessageId.HasValue && _hotspots.Count > 0)
                 {
                     for (int i = 0; i < _hotspots.Count; i++)
@@ -117,7 +117,7 @@ namespace AccessibilityMod.Services
             }
             catch (Exception ex)
             {
-                _currentIndex = 0;
+                _currentIndex = -1;
                 AccessibilityMod.Core.AccessibilityMod.Logger?.Error(
                     $"Error refreshing hotspots: {ex.Message}"
                 );

--- a/AccessibilityMod/Services/PointingNavigator.cs
+++ b/AccessibilityMod/Services/PointingNavigator.cs
@@ -14,7 +14,7 @@ namespace AccessibilityMod.Services
     public static class PointingNavigator
     {
         private static List<PointInfo> _points = new List<PointInfo>();
-        private static int _currentIndex = 0;
+        private static int _currentIndex = -1;
         private static bool _wasRunning = false;
 
         public class PointInfo
@@ -93,7 +93,7 @@ namespace AccessibilityMod.Services
         private static void OnPointingEnd()
         {
             _points.Clear();
-            _currentIndex = 0;
+            _currentIndex = -1;
         }
 
         /// <summary>
@@ -102,7 +102,7 @@ namespace AccessibilityMod.Services
         public static void RefreshPoints()
         {
             _points.Clear();
-            _currentIndex = 0;
+            _currentIndex = -1;
 
             try
             {


### PR DESCRIPTION
## Summary

- Fixes bracket navigation (`]`/`[`) in investigation and pointing modes to navigate to item 1 on first press
- Changed `_currentIndex` initialization from `0` to `-1` in `HotspotNavigator` and `PointingNavigator`
- Aligns behavior with other navigators (Evidence3D, Luminol, Fingerprint, etc.) that already worked correctly

## Problem

When entering investigation or pointing mode, pressing `]` would skip to item 2 instead of item 1. This was because:
- `_currentIndex` was initialized to `0`
- `NavigateNext()` increments first: `(_currentIndex + 1) % count`
- Result: `(0 + 1) % count = 1` → second item

## Solution

Initialize `_currentIndex = -1` so first press calculates `(-1 + 1) % count = 0` → first item.

## Test plan

- [ ] Enter investigation mode, press `]` - should announce "Point 1"
- [ ] Enter pointing mode, press `]` - should announce "Area 1"
- [ ] Verify `[` also works correctly (wraps to last item on first press)

🤖 Generated with [Claude Code](https://claude.com/claude-code)