### PR TITLE
fix: Use Update pattern for reliable investigation mode entry announcements

### DIFF
--- a/AccessibilityMod/Core/AccessibilityMod.cs
+++ b/AccessibilityMod/Core/AccessibilityMod.cs
@@ -110,6 +110,7 @@ namespace AccessibilityMod.Core
 
         private void UpdateNavigators()
         {
+            HotspotNavigator.Update();
             PointingNavigator.Update();
             LuminolNavigator.Update();
             VasePuzzleNavigator.Update();

--- a/AccessibilityMod/Patches/InvestigationPatches.cs
+++ b/AccessibilityMod/Patches/InvestigationPatches.cs
@@ -23,7 +23,8 @@ namespace AccessibilityMod.Patches
                 _lastCursorSprite = -1;
 
                 AccessibilityState.SetMode(AccessibilityState.GameMode.Investigation);
-                HotspotNavigator.OnInvestigationStart();
+                // Note: OnInvestigationStart() is now called from HotspotNavigator.Update()
+                // which reliably detects mode transitions via AccessibilityState.IsInInvestigationMode()
             }
             catch (Exception ex)
             {

--- a/AccessibilityMod/Services/HotspotNavigator.cs
+++ b/AccessibilityMod/Services/HotspotNavigator.cs
@@ -11,6 +11,7 @@ namespace AccessibilityMod.Services
     {
         private static List<HotspotInfo> _hotspots = new List<HotspotInfo>();
         private static int _currentIndex = -1;
+        private static bool _wasActive = false;
 
         public class HotspotInfo
         {
@@ -20,6 +21,33 @@ namespace AccessibilityMod.Services
             public float CenterY;
             public bool IsExamined;
             public string Description;
+        }
+
+        /// <summary>
+        /// Called each frame to detect when investigation mode starts/ends.
+        /// </summary>
+        public static void Update()
+        {
+            bool isActive = AccessibilityState.IsInInvestigationMode();
+
+            if (isActive && !_wasActive)
+            {
+                // Investigation mode just started
+                OnInvestigationStart();
+            }
+            else if (!isActive && _wasActive)
+            {
+                // Investigation mode just ended
+                OnInvestigationEnd();
+            }
+
+            _wasActive = isActive;
+        }
+
+        private static void OnInvestigationEnd()
+        {
+            _hotspots.Clear();
+            _currentIndex = -1;
         }
 
         public static void RefreshHotspots()


### PR DESCRIPTION
## Summary
- Fixed regression where investigation mode entry was only announced the first time
- Added `Update()` method with `_wasActive` tracking to `HotspotNavigator`, matching the pattern used by other navigators
- Removed duplicate `OnInvestigationStart()` call from Harmony patch to prevent double announcements

## Root Cause
The investigation mode entry announcement relied solely on a Harmony patch for `inspectCtrl.play()`, which wasn't reliably firing on subsequent entries. Other navigators like `LuminolNavigator` use an `Update()` pattern that runs every frame and detects mode transitions via state tracking - this is more reliable.

## Test plan
- [ ] Enter investigation mode - should announce "Investigation mode. X points..."
- [ ] Exit investigation mode (examine something or cancel)
- [ ] Re-enter investigation mode - should announce again (was broken before)
- [ ] Press I key during investigation - should still announce state correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)